### PR TITLE
Simplify guard for dss

### DIFF
--- a/src/guard.sol
+++ b/src/guard.sol
@@ -52,7 +52,6 @@ contract DSGuard {
     function canCall(
         address src, address dst, bytes4 sig
     ) public view returns (bool) {
-
         return acl[src][dst][sig];
     }
 


### PR DESCRIPTION
Simplifying DS-Guard for use in DSS.  This removes the external authority and adds `owner` directly to the Guard.

Two main differences from DS-Guard:
- No external calls to an authority
- canCall no longer allows `ANY`, each address must be authorized for a specific function call